### PR TITLE
Fix 'GetDescendants' method will case 'ArgumentException'

### DIFF
--- a/WinRTXamlToolkit/Controls/Extensions/VisualTreeHelperExtensions.cs
+++ b/WinRTXamlToolkit/Controls/Extensions/VisualTreeHelperExtensions.cs
@@ -158,7 +158,7 @@ namespace WinRTXamlToolkit.Controls.Extensions
                         }
                         else
                         {
-                            childrenCount = VisualTreeHelper.GetChildrenCount(start);
+                            childrenCount = VisualTreeHelper.GetChildrenCount(parent);
                         }
                     }
                     catch (Exception)


### PR DESCRIPTION
Fix 'GetDescendants' method get child count of 'start', it should be 'parent'.