### PR TITLE
Added some extra info to track possible reasons for focus loss. The r…

### DIFF
--- a/WinRTXamlToolkit.Debugging/ViewModels/VisualTreeViewModel.cs
+++ b/WinRTXamlToolkit.Debugging/ViewModels/VisualTreeViewModel.cs
@@ -25,7 +25,10 @@ namespace WinRTXamlToolkit.Debugging.ViewModels.Stubs
         {
             foreach (var resourceKeyValue in source)
             {
-                target.Add(resourceKeyValue.Key, resourceKeyValue.Value);
+                if (!target.ContainsKey(resourceKeyValue.Key))
+                {
+                    target.Add(resourceKeyValue.Key, resourceKeyValue.Value);
+                }
             }
 
             foreach (var dictionary in source.MergedDictionaries)
@@ -39,7 +42,10 @@ namespace WinRTXamlToolkit.Debugging.ViewModels.Stubs
             {
                 var clone = new ResourceDictionary();
                 Clone((ResourceDictionary)dictionaryKeyValue.Value, clone);
-                target.ThemeDictionaries.Add(dictionaryKeyValue.Key, clone);
+                if (!target.ContainsKey(dictionaryKeyValue.Key))
+                {
+                    target.ThemeDictionaries.Add(dictionaryKeyValue.Key, clone);
+                }
             }
         }
 

--- a/WinRTXamlToolkit.Debugging/Views/FocusTrackerToolWindow.xaml
+++ b/WinRTXamlToolkit.Debugging/Views/FocusTrackerToolWindow.xaml
@@ -31,6 +31,9 @@
                             <TextBlock
                                 FontWeight="{Binding Element.FontWeight}"
                                 Text="{Binding Element.DisplayName}" />
+                            <TextBlock
+                                FontStyle="Italic"
+                                Text="{Binding FocusLossPossibleReason}" />
                         </StackPanel>
                     </DataTemplate>
                 </ListView.ItemTemplate>


### PR DESCRIPTION
…eason really turned out to be a ContentDialog which would prevent elements from outside of it getting focus during PrimaryButtonPressed event handling.